### PR TITLE
add channel options to midi device:

### DIFF
--- a/src/synth-ui/components/filter.tsx
+++ b/src/synth-ui/components/filter.tsx
@@ -4,7 +4,7 @@ import { IModuleProps } from './module';
 import { modules } from './module-map';
 import { Parameter } from './parameter';
 import { Connector } from './connector';
-import { Setting } from './setting';
+import { SettingRadio } from './setting';
 
 const { v4 } = require('uuid');
 
@@ -184,7 +184,7 @@ export const Filter: React.FunctionComponent<IModuleProps> = props => {
 				display={displayGain}
 				onChange={handleChangeGain}
 				type={'CV_IN'} />
-			<Setting
+			<SettingRadio
 				name="type"
 				value={type}
 				options={filterTypeOptions}

--- a/src/synth-ui/components/midi-device.tsx
+++ b/src/synth-ui/components/midi-device.tsx
@@ -3,9 +3,28 @@ import { MidiOutput } from './midi-output';
 import { IModuleProps } from './module';
 import { modules } from './module-map';
 import { Connector } from './connector';
-import { Setting } from './setting';
+import { SettingSelect } from './setting';
 import webmidi from 'webmidi';
 
+const channelOptions: [string, string][] = [
+	['all', 'all'],
+	['1', '1'],
+	['2', '2'],
+	['3', '3'],
+	['4', '4'],
+	['5', '5'],
+	['6', '6'],
+	['7', '7'],
+	['8', '8'],
+	['9', '9'],
+	['10', '10'],
+	['11', '11'],
+	['12', '12'],
+	['13', '13'],
+	['14', '14'],
+	['15', '15'],
+	['16', '16']
+];
 
 const { v4 } = require('uuid');
 
@@ -13,6 +32,7 @@ export const MidiDevice: React.FunctionComponent<IModuleProps> = props => {
 	const [outputId] = React.useState(v4() as any);
 	const [inputDevices] = React.useState(webmidi.inputs);
 	const [inputDevice, setInputDevice] = React.useState('');
+	const [inputChannel, setInputChannel] = React.useState('all');
 	const [module] = React.useState(modules.get(props.moduleKey));
 
 	if (module && !module.initialized) {
@@ -31,16 +51,26 @@ export const MidiDevice: React.FunctionComponent<IModuleProps> = props => {
 	const handleChangeInputDevice = React.useCallback((newDevice: string) => {
 		module && module.node.switchInputDevice(newDevice);
 		setInputDevice(newDevice);
-	}, [module]);
+	}, [module, inputDevice]);
+
+	const handleChangeInputChannel = React.useCallback((newChannel: string) => {
+		module && module.node.switchInputChannel(newChannel);
+		setInputChannel(newChannel);
+	}, [module, inputChannel]);
 
 	return (
 		<article>
 			<h2>midi device</h2>
-			<Setting
+			<SettingSelect
 				name="device"
 				value={inputDevice}
 				options={inputDevices.map((device: any) => [device.name as string, device.name as string])}
 				onChange={handleChangeInputDevice} />
+			<SettingSelect
+				name="channel"
+				value={inputChannel}
+				options={channelOptions}
+				onChange={handleChangeInputChannel} />
 			<Connector
 				type="MIDI_OUT"
 				name="output"

--- a/src/synth-ui/components/midi-oscillator.tsx
+++ b/src/synth-ui/components/midi-oscillator.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { IModuleProps } from './module';
 import { modules } from './module-map';
 import { audioContext } from '../audio/audio-context';
-import { Setting } from './setting';
+import { SettingRadio, SettingSelect } from './setting';
 import { Connector } from './connector';
 import { MidiInput } from './midi-input';
 import { midiToFrequency } from '../audio/midi-to-frequency';
@@ -146,7 +146,7 @@ export class MidiOscillator extends React.Component<IModuleProps, IMidiOscillato
 					name="midi input"
 					moduleKey={this.props.moduleKey}
 					connectorId={this.state.midiInputId} />
-				<Setting
+				<SettingSelect
 					name="type"
 					value={this.state.type}
 					options={oscillatorTypeOptions}

--- a/src/synth-ui/components/midi-output.ts
+++ b/src/synth-ui/components/midi-output.ts
@@ -4,21 +4,29 @@ import webmidi from "webmidi";
 export class MidiOutput {
 	private _connections: Map<string, MidiInput> = new Map<string, MidiInput>();
 	private _input: any;
+	private _channel = 'all';
 	constructor() {
 		this._handleNoteOn = this._handleNoteOn.bind(this);
 		this._handleNoteOff = this._handleNoteOff.bind(this);
 		this._input = webmidi.inputs[0];
 		if (this._input) {
-			this._input.addListener('noteon', 'all', this._handleNoteOn);
-			this._input.addListener('noteoff', 'all', this._handleNoteOff);
+			this._input.addListener('noteon', this._channel, this._handleNoteOn);
+			this._input.addListener('noteoff', this._channel, this._handleNoteOff);
 		}
 	}
 	public switchInputDevice(to: string) {
-		this._input.removeListener('noteon', 'all', this._handleNoteOn);
-		this._input.removeListener('noteoff', 'all', this._handleNoteOff);
+		this._input.removeListener('noteon', this._channel, this._handleNoteOn);
+		this._input.removeListener('noteoff', this._channel, this._handleNoteOff);
 		this._input = webmidi.inputs.find((input: any) => input.name === to);
-		this._input.addListener('noteon', 'all', this._handleNoteOn);
-		this._input.addListener('noteoff', 'all', this._handleNoteOff);
+		this._input.addListener('noteon', this._channel, this._handleNoteOn);
+		this._input.addListener('noteoff', this._channel, this._handleNoteOff);
+	}
+	public switchInputChannel(to: string) {
+		this._input.removeListener('noteon', this._channel, this._handleNoteOn);
+		this._input.removeListener('noteoff', this._channel, this._handleNoteOff);
+		this._channel = to;
+		this._input.addListener('noteon', this._channel, this._handleNoteOn);
+		this._input.addListener('noteoff', this._channel, this._handleNoteOff);
 	}
 	public connect(to: MidiInput) {
 		this._connections.set(to.id, to);

--- a/src/synth-ui/components/oscillator.tsx
+++ b/src/synth-ui/components/oscillator.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { IModuleProps } from './module';
 import { modules } from './module-map';
 import { audioContext } from '../audio/audio-context';
-import { Setting } from './setting';
+import { SettingRadio } from './setting';
 import { Parameter } from './parameter';
 import { Connector } from './connector';
 
@@ -111,7 +111,7 @@ export const Oscillator: React.FunctionComponent<IModuleProps> = props => {
 				display={displayDetune}
 				onChange={handleChangeDetune}
 				type={'CV_IN'} />
-			<Setting
+			<SettingRadio
 				name="type"
 				value={type}
 				options={oscillatorTypeOptions}

--- a/src/synth-ui/components/setting.tsx
+++ b/src/synth-ui/components/setting.tsx
@@ -9,7 +9,7 @@ export interface ISettingProps {
 	onChange: (newValue: string) => void;
 }
 
-export const Setting: React.FunctionComponent<ISettingProps> = props => {
+export const SettingRadio: React.FunctionComponent<ISettingProps> = props => {
 	const [id] = React.useState(v4() as string);
 
 	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -25,6 +25,25 @@ export const Setting: React.FunctionComponent<ISettingProps> = props => {
 					<label htmlFor={`${id}_${option[0]}`}>{option[1]}</label>
 				</span>
 			))}
+		</fieldset>
+	);
+};
+
+export const SettingSelect: React.FunctionComponent<ISettingProps> = props => {
+	const [id] = React.useState(v4() as string);
+
+	const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+		props.onChange(e.target.value);
+	};
+
+	return (
+		<fieldset className="setting">
+			<legend>{props.name}</legend>
+			<select value={props.value} onChange={handleChange}>
+				{props.options.map((option, index) => (
+					<option value={option[0]}>{option[1]}</option>
+				))}
+			</select>
 		</fieldset>
 	);
 };


### PR DESCRIPTION
- midi devices can now select their channel, defaulting to 'all'

- an alternative to Setting was added, SettingSelect. Setting was renamed to SettingRadio