### PR TITLE
Module architecture

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+	"trailingComma": "none",
+	"useTabs": true,
+	"tabWidth": 2,
+	"semi": true,
+	"singleQuote": true
+}

--- a/src/modules/oscillator.tsx
+++ b/src/modules/oscillator.tsx
@@ -1,33 +1,41 @@
-import * as React from 'react';
+// use react when custom render is present
+// import * as React from 'react';
+
+// ParameterTypes should be imported from the platform
+const ParameterTypes = {
+	SIGNAL_OUT: 'SIGNAL_OUT',
+	CV_IN: 'CV_IN',
+	SETTINGS: 'SETTINGS'
+};
 
 class Oscillator {
 	node: any; // reference to the connectable node
 	name: string = 'Oscillator'; //  used for the UI
 
-	// returns parameter descriptors
+	// returns static serializable parameter descriptors
 	getParameters() {
 		return [
 			{
 				name: 'output',
-				type: 'SIGNAL_OUT'
+				type: ParameterTypes.SIGNAL_OUT
 			},
 			{
 				name: 'frequency',
-				type: 'CV_IN',
+				type: ParameterTypes.CV_IN,
 				defaultValue: 440,
 				min: 0,
 				max: 20000
 			},
 			{
 				name: 'detune',
-				type: 'CV_IN',
+				type: ParameterTypes.CV_IN,
 				defaultValue: 0,
 				min: -100,
 				max: 100
 			},
 			{
 				name: 'type',
-				type: 'SETTINGS',
+				type: ParameterTypes.SETTINGS,
 				// why not a simple array here
 				// and use the display() function
 				// for the label in the select?

--- a/src/modules/oscillator.tsx
+++ b/src/modules/oscillator.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+
+class Oscillator {
+	node: any; // reference to the connectable node
+	name: string = 'Oscillator'; //  used for the UI
+
+	// returns parameter descriptors
+	getParameters() {
+		return [
+			{
+				name: 'output',
+				type: 'SIGNAL_OUT'
+			},
+			{
+				name: 'frequency',
+				type: 'CV_IN',
+				defaultValue: 440,
+				min: 0,
+				max: 20000
+			},
+			{
+				name: 'detune',
+				type: 'CV_IN',
+				defaultValue: 0,
+				min: -100,
+				max: 100
+			},
+			{
+				name: 'type',
+				type: 'SETTINGS',
+				// why not a simple array here
+				// and use the display() function
+				// for the label in the select?
+				options: [
+					['sine', 'sin'],
+					['triangle', 'tri'],
+					['square', 'sqr'],
+					['sawtooth', 'saw']
+				],
+				defaultValue: 'sine'
+			}
+		];
+	}
+
+	//  initialize the audio graph of the module
+	// and return the connectable point
+	setup(audio: any) {
+		// NOTE: audio type should be exported from audio-om
+		this.node = audio.node(audio.createOscillator());
+		this.node.start();
+		return this.node;
+	}
+
+	// state here is passed by the system with updated state from UI
+	// so we can update our nodes accordingly
+	update(state: any) {
+		this.node.type = state.type;
+		this.node.detune.value = state.detune;
+		this.node.frequency.value = state.frequency;
+	}
+
+	// TODO: implement the custom render case
+	// render({ params, state, update, moduleKey }: any) {
+	//   // state is still handled by the module loader
+	//   // update callback is passed
+	//   // return some jsx
+	//   return <>Cool</>
+	// }
+}
+
+export default Oscillator;

--- a/src/synth-kitchen/components/modules/Oscillator.tsx
+++ b/src/synth-kitchen/components/modules/Oscillator.tsx
@@ -43,7 +43,7 @@ const ModuleLoader: React.FunctionComponent<IModuleProps> = (props) => {
 	// UIState
 	const [uiState, setUIState] = React.useState({} as Record<string, any>);
 	// ModuleLoader values
-	const { params, unit } = state;
+	const { module, params, unit } = state;
 
 	// Build the module only on first render pass
 	React.useEffect(() => {
@@ -51,6 +51,7 @@ const ModuleLoader: React.FunctionComponent<IModuleProps> = (props) => {
 
 		if (module && audio) {
 			const unit = new OscillatorModule();
+			const node = unit.setup(audio);
 			// hydrate static params
 			const params: Params = unit.getParameters().map(
 				(param) =>
@@ -59,7 +60,7 @@ const ModuleLoader: React.FunctionComponent<IModuleProps> = (props) => {
 						...param,
 						id: uniqueId(),
 						getter: () =>
-							param.type === 'SIGNAL_OUT' ? unit.node : uiState[param.name]
+							param.type === 'SIGNAL_OUT' ? node : uiState[param.name]
 					} as any)
 			);
 
@@ -73,7 +74,7 @@ const ModuleLoader: React.FunctionComponent<IModuleProps> = (props) => {
 				{}
 			);
 
-			module.node = unit.setup(audio);
+			module.node = node;
 			module.connectors = params;
 
 			setState({ ...state, module, params, unit });

--- a/src/synth-kitchen/components/modules/shared/index.ts
+++ b/src/synth-kitchen/components/modules/shared/index.ts
@@ -1,0 +1,3 @@
+export * from './Connector';
+export * from './Parameter';
+export * from './Setting';


### PR DESCRIPTION
This PR sets up one example of a possible module architecture.

## Motivation
Ideally contributing modules to the platform should be as easy as possible.  
This architecture proposes the following Module structure:
```
class MyModule {
  name: string // module name for the main UI
 
  // returns a static seralizable description of the parameters
   getParameters(): ModuleParameterList {}

  // receives the main audio context and initialises the internal audio graph
  // returns the main WebAudionode node that can be connected
   setup(ctx: audioContext): WebAudionode {}

  // called when state changes receives new state and changes nodes accordingly
   update(state: ModuleState): void {}

  // optional render method receives top level dependencies and returns custom UI
   render(props: ModuleProps) : React.Element
}
```
For a reference implementation see [Oscillator.tsx](https://github.com/spencerudnick/synth.kitchen/compare/main...vectorsize:module-architecture?expand=1#diff-46c0da2b3cb7101edb17bf1e06f825e0d96941e2de47393e44784910fe5576f0)

The original [Oscillator.tsx](https://github.com/spencerudnick/synth.kitchen/compare/main...vectorsize:module-architecture?expand=1#diff-cb73cb7d296aa4d12961a5b78d61c9f2b256078308d90e931e25e6c0f64e8a4e) is used as an example `ModuleLoader` which is in charge of dynamically loading a given user or core module.

The Modules are separate `npm` packages implemented with the proposed APIs and exported types and can be added to the platform via `npm install`.
Finally a top level component will import all of those (could perhaps be done dynamically) and make them available to the patcher.

PS: never mind [this file](https://github.com/spencerudnick/synth.kitchen/compare/main...vectorsize:module-architecture?expand=1#diff-b6b03a7537abc29424237ba32780b98413e49524c665190971ea59e59b200e6d) no longer needed.